### PR TITLE
Remove G+

### DIFF
--- a/XDA_ThreadTemplate [Android 9.x Pie]
+++ b/XDA_ThreadTemplate [Android 9.x Pie]
@@ -27,7 +27,7 @@ Read the whole OP! Be respectful to each other and don't ask for ETAs, it's cons
 [img]http://i.imgur.com/Np7jfnY.png[/img]
 
 
-[B][SIZE="4"]#ExtendYourDevice Here are the Extensions! on top of AOSP! We are constantly trying to update the list. Our aim is not to provide all the features available on earth. Our aim is to add important features that we think should be here and also what you think. For addition of more tweaks or features, head on to our G+ community and post the list of features that you want! Features with commits will be more helpful![/SIZE][/B]
+[B][SIZE="4"]#ExtendYourDevice Here are the Extensions! on top of AOSP! We are constantly trying to update the list. Our aim is not to provide all the features available on earth. Our aim is to add important features that we think should be here and also what you think. For addition of more tweaks or features, head on to our Telegram group chat and post the list of features that you want! Features with commits will be more helpful![/SIZE][/B]
 
 
 
@@ -204,14 +204,14 @@ If you want any bug to be fixed please write here on xda in detail. Give Logcats
 
 
 [SIZE="4"][B]
-Visit our [URL="https://www.aospextended.com/"][COLOR="Blue"]Website,[/COLOR][/URL] join our [URL="https://plus.google.com/u/0/communities/106726906578669931141"][COLOR="Red"]Google+ Community,[/COLOR][/URL] Subscribe to our [URL="https://telegram.me/aospextended"][COLOR="RoyalBlue"]Telegram Channel. [/COLOR][/URL]Also join our [URL="https://telegram.me/aospextendedgroup"][COLOR="RoyalBlue"]Telegram Group Chat![/COLOR][/URL]
+Visit our [URL="https://www.aospextended.com/"][COLOR="Blue"]Website,[/COLOR][/URL], Subscribe to our [URL="https://telegram.me/aospextended"][COLOR="RoyalBlue"]Telegram Channel. [/COLOR][/URL]Also join our [URL="https://telegram.me/aospextendedgroup"][COLOR="RoyalBlue"]Telegram Group Chat![/COLOR][/URL]
 
-Do you want to translate to your language? Visit our [URL="http://translate.aospextended.com/"][COLOR="Green"]Crowdin[/COLOR][/URL][/B][/SIZE]
+Do you want to translate AospExtended to your language? Visit our [URL="http://translate.aospextended.com/"][COLOR="Green"]Crowdin[/COLOR][/URL][/B][/SIZE]
 
 [img]http://i.imgur.com/wxV7wmi.png[/img]
 
 
-[B][SIZE="4"][COLOR="Black"] All sort of contributions are welcomed. You can post your walls in our G+ community. Minimum res we require is W: 1152px | H: 2048px. We don't want our users to fight with each other so we humbly request you to be respectful to each other. We are not earning anything by sharing this ROM. Always read the full OP. Don't Quote the whole OP. Join our channel and community. #StayHappy #ExtendYourDevice[/COLOR][/SIZE][/B]
+[B][SIZE="4"][COLOR="Black"] All sort of contributions are welcomed. You can post your walls in our Telegram group chat. Minimum res we require is W: 1152px | H: 2048px. We don't want our users to fight with each other so we humbly request you to be respectful to each other. We are not earning anything by sharing this ROM. Always read the full OP. Don't Quote the whole OP. Join our channel and community. #StayHappy #ExtendYourDevice[/COLOR][/SIZE][/B]
 
 
 [img]http://i.imgur.com/GDeu02t.png[/img]
@@ -237,7 +237,6 @@ YOUR ATTACHMENTS COMES HERE FOR SCREENSHOTS[/B][/SIZE]
 -[URL="https://github.com/omnirom"]OmniROM[/URL]
 -[URL="https://github.com/aospa"]AOSPA[/URL]
 -[URL="https://github.com/ezio84"]ABC ROM[/URL]
--[URL="https://plus.google.com/communities/109330559573276360638"]GZR Community[/URL]
 -[URL="https://github.com/LakorTi"]Lakor Tools[/URL] for Via Browser
 -[URL="https://github.com/h4h13"]Hemanth S Tobi[/URL] for Retro Music Player
 -[MENTION=7580472]AlienCreature7[/MENTION], [MENTION=7772507]Wizper99[/MENTION], [MENTION=7751333]Allstargaurav[/MENTION], [MENTION=7820332]Edozullo[/MENTION] and [MENTION=6357786]harsh sharma[/MENTION] (For designing the ROM Logo, Fling etc)[/SIZE][/B]


### PR DESCRIPTION
I have removed all mentions of G+, as it has been killed by Google. Any instructions to post in G+ have been replaced with Telegram.